### PR TITLE
More robust test of content in hdf5 attributes before writing to file

### DIFF
--- a/midgard/data/_h5utils.py
+++ b/midgard/data/_h5utils.py
@@ -11,6 +11,11 @@ from typing import Any, Dict, List, Tuple, Set
 def encode_h5attr(data: Any) -> Any:
     """Convert a basic data type to something that can be saved as a hdf5 attribute"""
     data_type = type(data).__name__
+    if data_type != "str":
+        # Check if the data being written can be read by literal_eval.
+        # Will raise ValueError if the data is too complex
+        ast.literal_eval(str(data))
+
     try:
         return globals()[f"_{data_type}2h5attr"](data)
     except KeyError:

--- a/midgard/data/dataset.py
+++ b/midgard/data/dataset.py
@@ -412,10 +412,7 @@ class Meta(UserDict):
     def write(self, h5_group):
         """Write meta data to hdf5-file"""
         for k, v in self.items():
-            try:
-                h5_group.attrs[k] = _h5utils.encode_h5attr(v)
-            except ValueError:
-                raise ValueError(f"Cannot save attribute '{k}' in meta. Data too complex: {v}. See ast.literal_eval for supported data types.")
+            h5_group.attrs[k] = _h5utils.encode_h5attr(v)
 
     def add(self, name: Hashable, value: Collection, section: Optional[Hashable] = None) -> None:
         """Add information to the metaset"""

--- a/midgard/data/dataset.py
+++ b/midgard/data/dataset.py
@@ -412,7 +412,10 @@ class Meta(UserDict):
     def write(self, h5_group):
         """Write meta data to hdf5-file"""
         for k, v in self.items():
-            h5_group.attrs[k] = _h5utils.encode_h5attr(v)
+            try:
+                h5_group.attrs[k] = _h5utils.encode_h5attr(v)
+            except ValueError:
+                raise ValueError(f"Cannot save attribute '{k}' in meta. Data too complex: {v}. See ast.literal_eval for supported data types.")
 
     def add(self, name: Hashable, value: Collection, section: Optional[Hashable] = None) -> None:
         """Add information to the metaset"""

--- a/midgard/data/dataset.py
+++ b/midgard/data/dataset.py
@@ -404,13 +404,21 @@ class Dataset(collection.Collection):
 
 
 class Meta(UserDict):
-    def read(self, h5_group):
-        """Read meta data from hdf5-file"""
+    def read(self, h5_group: h5py.Group) -> None:
+        """Read meta data from hdf5-file
+        
+        Args:
+            h5_group:    The hdf5 group that contains the meta data
+        """
         for k, v in h5_group.attrs.items():
             self.data[k] = _h5utils.decode_h5attr(v)
 
-    def write(self, h5_group):
-        """Write meta data to hdf5-file"""
+    def write(self, h5_group: h5py.Group) -> None:
+        """Write meta data to hdf5-file
+
+        Args:
+            h5_group:   The hdf5 group to store the meta data in
+        """
         for k, v in self.items():
             h5_group.attrs[k] = _h5utils.encode_h5attr(v)
 

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -730,25 +730,16 @@ def test_delete(dset_full):
     with pytest.raises(AttributeError):
         dset_full.numbers_2
 
-def dset_meta_error_msg():
+@pytest.mark.parametrize("type_": [
+    (datetime.now()),
+    (tuple(datetime.now())),
+    ({"b": datetime.now()}),
+    ([[[[datetime.now()]]]]),
+])
+def dset_meta_error_msg(type_):
     # Too complex datatype is being saved to meta and should give error message
 
-    _dset1 = dataset.Dataset()
-    _dset1.meta.add("a", datetime.now())
+    _dset = dataset.Dataset()
+    _dset.meta.add("a", type_)
     with pytest.raises(TypeError):
-        _dset1.write("test.hdf5")
-
-    _dset2 = dataset.Dataset()
-    _dset2.meta.add("a", tuple(datetime.now()))
-    with pytest.raises(TypeError):
-        _dset2.write("test.hdf5")
-
-    _dset3 = dataset.Dataset()
-    _dset3.meta.add("a", {"b": datetime.now()})
-    with pytest.raises(TypeError):
-        _dset3.write("test.hdf5")
-
-    _dset4 = dataset.Dataset()
-    _dset4.meta.add("a", [[[[datetime.now()]]]])
-    with pytest.raises(TypeError):
-        _dset4.write("test.hdf5")
+        _dset.write("test.hdf5")

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -729,3 +729,26 @@ def test_delete(dset_full):
         dset_full.numbers_1
     with pytest.raises(AttributeError):
         dset_full.numbers_2
+
+def dset_meta_error_msg():
+    # Too complex datatype is being saved to meta and should give error message
+
+    _dset1 = dataset.Dataset()
+    _dset1.meta.add("a", datetime.now())
+    with pytest.raises(TypeError):
+        _dset1.write("test.hdf5")
+
+    _dset2 = dataset.Dataset()
+    _dset2.meta.add("a", tuple(datetime.now()))
+    with pytest.raises(TypeError):
+        _dset2.write("test.hdf5")
+
+    _dset3 = dataset.Dataset()
+    _dset3.meta.add("a", {"b": datetime.now()})
+    with pytest.raises(TypeError):
+        _dset3.write("test.hdf5")
+
+    _dset4 = dataset.Dataset()
+    _dset4.meta.add("a", [[[[datetime.now()]]]])
+    with pytest.raises(TypeError):
+        _dset4.write("test.hdf5")


### PR DESCRIPTION
Test of pull request. 

When writing to dataset to hdf5, verify that attributes saved in the hdf5 file can be interpreted correctly when reading the file. When the verification fails, give en error message instead for writing the file.