### PR TITLE
Update test_dataset.py

### DIFF
--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -730,9 +730,9 @@ def test_delete(dset_full):
     with pytest.raises(AttributeError):
         dset_full.numbers_2
 
-@pytest.mark.parametrize("type_": [
+@pytest.mark.parametrize("type_", [
     (datetime.now()),
-    (tuple(datetime.now())),
+    ((datetime.now(),)),
     ({"b": datetime.now()}),
     ([[[[datetime.now()]]]]),
 ])


### PR DESCRIPTION
Syntax failure changed in line 733 and replaced tuple(datetime.now()) with (datetime.now(), ) in line 735.