### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @annsilje
+/.security/ @annsilje

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Geodesi
 product: 
 repo_types: [Library]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,29 +9,3 @@ spec:
   type: "library"
   lifecycle: "production"
   owner: "geodesi_devops"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_midgard"
-  title: "Security Champion midgard"
-spec:
-  type: "security_champion"
-  parent: "geodesi_security_champions"
-  members:
-  - "annsilje"
-  children:
-  - "resource:midgard"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "midgard"
-  links:
-  - url: "https://github.com/kartverket/midgard"
-    title: "midgard på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_midgard"
-  dependencyOf:
-  - "component:midgard"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml